### PR TITLE
Lower upcloud-api requirements to newest available (0.3.3).

### DIFF
--- a/modules/upcloud.py
+++ b/modules/upcloud.py
@@ -109,7 +109,7 @@ notes:
     - Better description of UpCloud's API available at U(www.upcloud.com/api/)
 requirements:
   - "python >= 2.6"
-  - "upcloud-api >= 0.3.4"
+  - "upcloud-api >= 0.3.3"
 '''
 
 EXAMPLES = '''
@@ -156,7 +156,7 @@ try:
     import upcloud_api
     from upcloud_api import CloudManager
 
-    if LooseVersion(upcloud_api.__version__) < LooseVersion('0.3.4'):
+    if LooseVersion(upcloud_api.__version__) < LooseVersion('0.3.3'):
         HAS_UPCLOUD = False
 
 except ImportError, e:

--- a/modules/upcloud_firewall.py
+++ b/modules/upcloud_firewall.py
@@ -49,7 +49,7 @@ notes:
     - Better description of UpCloud's API available at U(www.upcloud.com/api/)
 requirements:
   - "python >= 2.6"
-  - "upcloud-api >= 0.3.4"
+  - "upcloud-api >= 0.3.3"
 '''
 
 EXAMPLES = '''

--- a/modules/upcloud_tag.py
+++ b/modules/upcloud_tag.py
@@ -51,7 +51,7 @@ notes:
     - Better description of UpCloud's API available at U(www.upcloud.com/api/)
 requirements:
   - "python >= 2.6"
-  - "upcloud-api >= 0.3.4"
+  - "upcloud-api >= 0.3.3"
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
I got error while using `upcloud:` directive.

```
failed: [localhost] (item={ ... "msg": "upcloud-api required for this module (`pip install upcloud-api`)"}
```

Even though I had already installed upcloud-api through pip:

```
$ pip install upcloud-api
Requirement already satisfied (use --upgrade to upgrade): upcloud-api in /usr/local/lib/python2.7/site-packages
Requirement already satisfied (use --upgrade to upgrade): responses==0.3.0 in /usr/local/lib/python2.7/site-packages (from upcloud-api)
Requirement already satisfied (use --upgrade to upgrade): wheel==0.24.0 in /usr/local/lib/python2.7/site-packages (from upcloud-api)
Requirement already satisfied (use --upgrade to upgrade): mock==1.0.1 in /usr/local/lib/python2.7/site-packages (from upcloud-api)
Requirement already satisfied (use --upgrade to upgrade): pytest==2.6.4 in /usr/local/lib/python2.7/site-packages (from upcloud-api)
Requirement already satisfied (use --upgrade to upgrade): six==1.9.0 in /usr/local/lib/python2.7/site-packages (from upcloud-api)
Requirement already satisfied (use --upgrade to upgrade): requests==2.6.0 in /usr/local/lib/python2.7/site-packages (from upcloud-api)
Requirement already satisfied (use --upgrade to upgrade): py==1.4.26 in /usr/local/lib/python2.7/site-packages (from upcloud-api)
Requirement already satisfied (use --upgrade to upgrade): future==0.14.3 in /usr/local/lib/python2.7/site-packages (from upcloud-api)
```

[upcloud-python-api](https://github.com/UpCloudLtd/upcloud-python-api) doesn't even have `0.3.4` version so I lowered the requirements to newest available.

I think this version requirement was just a typo.
