### PR TITLE
Include non-fqdn hostname in inventory

### DIFF
--- a/inventory/upcloud.ini
+++ b/inventory/upcloud.ini
@@ -14,3 +14,4 @@
 # flag to return public IP-addresses instead of hostnames
 
 return_ip_addresses = True
+return_non_fqdn_names = True


### PR DESCRIPTION
Populate inventory with non-fqdn hostnames as well. This is useful in many cases when you want to use short names in scripts or commands, but fqdn names in upcloud hostnames.