### PR TITLE
Configurable timeout param

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Note for OS X users:
 * you may wish to use `return_ip_addresses = True` in .ini to ensure that SSH works (hostnames may not be in DNS)
 * information on configuring the inventory without specifying `-i` every time:
 [http://stackoverflow.com/questions/21958727/where-to-store-ansible-host-file-on-osx](http://stackoverflow.com/questions/21958727/where-to-store-ansible-host-file-on-osx)
+* Define upcloud api user and password in the .ini file or in env variables.
+* Default timeout is defined either in the .ini file or as env variable. (default is 300s)
 
 **Usage**
 

--- a/inventory/upcloud.ini
+++ b/inventory/upcloud.ini
@@ -14,7 +14,7 @@
 # flag to return public IP-addresses instead of hostnames
 
 # Server creation takes time in some zones, so the default_timeout is reflective of that.
-# Feel free to change according to your needs. You can also set this in env variables as UPCLOUD_API_DEFTIMEOUT
+# Feel free to change according to your needs. You can also set this in env variables as UPCLOUD_API_TIMEOUT
 # If default_timeout is not defined we will wait forever for a response
 
 return_ip_addresses = True

--- a/inventory/upcloud.ini
+++ b/inventory/upcloud.ini
@@ -13,5 +13,10 @@
 # to be unique nor accessible via SSH. Uncomment return_ip_addresses or provde --return-ip-addresses
 # flag to return public IP-addresses instead of hostnames
 
+# Server creation takes time in some zones, so the default_timeout is reflective of that.
+# Feel free to change according to your needs. You can also set this in env variables as UPCLOUD_API_DEFTIMEOUT
+# If default_timeout is not defined we will wait forever for a response
+
 return_ip_addresses = True
 return_non_fqdn_names = False
+default_timeout = 300

--- a/inventory/upcloud.py
+++ b/inventory/upcloud.py
@@ -232,7 +232,10 @@ if __name__ == "__main__":
 
     # setup API connection
     username, password = read_api_credentials(config)
-    manager = upcloud_api.CloudManager(username, password, 300)
+    default_timeout = os.getenv('UPCLOUD_API_DEFTIMEOUT')
+    if not default_timeout:
+        default_timeout = config.get('upcloud', 'default_timeout') or None
+    manager = upcloud_api.CloudManager(username, password, default_timeout)
 
     # decide whether to return hostnames or ip_addresses
     with_ip_addresses = False

--- a/inventory/upcloud.py
+++ b/inventory/upcloud.py
@@ -232,7 +232,7 @@ if __name__ == "__main__":
 
     # setup API connection
     username, password = read_api_credentials(config)
-    default_timeout = os.getenv('UPCLOUD_API_DEFTIMEOUT')
+    default_timeout = os.getenv('UPCLOUD_API_TIMEOUT')
     if not default_timeout:
         default_timeout = config.get('upcloud', 'default_timeout') or None
     manager = upcloud_api.CloudManager(username, password, default_timeout)

--- a/inventory/upcloud.py
+++ b/inventory/upcloud.py
@@ -232,7 +232,7 @@ if __name__ == "__main__":
 
     # setup API connection
     username, password = read_api_credentials(config)
-    manager = upcloud_api.CloudManager(username, password)
+    manager = upcloud_api.CloudManager(username, password, 300)
 
     # decide whether to return hostnames or ip_addresses
     with_ip_addresses = False

--- a/modules/upcloud.py
+++ b/modules/upcloud.py
@@ -166,8 +166,8 @@ except ImportError, e:
 class ServerManager():
     """Helpers for managing upcloud.Server instance"""
 
-    def __init__(self, api_user, api_passwd):
-        self.manager = CloudManager(api_user, api_passwd, 300)
+    def __init__(self, api_user, api_passwd, default_timeout):
+        self.manager = CloudManager(api_user, api_passwd, default_timeout)
 
 
     def find_server(self, uuid, hostname):
@@ -314,6 +314,9 @@ def main():
 
     api_user = module.params.get('api_user') or os.getenv('UPCLOUD_API_USER')
     api_passwd = module.params.get('api_passwd') or os.getenv('UPCLOUD_API_PASSWD')
+    default_timeout = os.getenv('UPCLOUD_API_DEFTIMEOUT')
+    if not default_timeout:
+        default_timeout = module.params.get('upcloud', 'default_timeout') or None
 
     if not api_user or not api_passwd:
         module.fail_json(msg='''Please set UPCLOUD_API_USER and UPCLOUD_API_PASSWD environment variables or provide api_user and api_passwd arguments.''')
@@ -323,7 +326,7 @@ def main():
     # Note: UpCloud's API has good error messages that the api client passes on.
     #
 
-    server_manager = ServerManager(api_user, api_passwd)
+    server_manager = ServerManager(api_user, api_passwd, default_timeout)
     try:
         run(module, server_manager)
     except Exception as e:

--- a/modules/upcloud.py
+++ b/modules/upcloud.py
@@ -314,7 +314,7 @@ def main():
 
     api_user = module.params.get('api_user') or os.getenv('UPCLOUD_API_USER')
     api_passwd = module.params.get('api_passwd') or os.getenv('UPCLOUD_API_PASSWD')
-    default_timeout = os.getenv('UPCLOUD_API_DEFTIMEOUT')
+    default_timeout = os.getenv('UPCLOUD_API_TIMEOUT')
     if not default_timeout:
         default_timeout = module.params.get('upcloud', 'default_timeout') or None
 

--- a/modules/upcloud.py
+++ b/modules/upcloud.py
@@ -167,7 +167,7 @@ class ServerManager():
     """Helpers for managing upcloud.Server instance"""
 
     def __init__(self, api_user, api_passwd):
-        self.manager = CloudManager(api_user, api_passwd)
+        self.manager = CloudManager(api_user, api_passwd, 300)
 
 
     def find_server(self, uuid, hostname):


### PR DESCRIPTION
Add default_timeout param to upcloud.ini ansible settings file. With this PR users can configure their timeout in the .ini file or as UPCLOUD_API_TIMEOUT env variable.